### PR TITLE
improve dispaching KeyboardEvent (for Speaker Deck)

### DIFF
--- a/src/presentation-joy-con.js
+++ b/src/presentation-joy-con.js
@@ -12,8 +12,8 @@
         const activeElement = document.activeElement;
         const global = activeElement.tagName === 'IFRAME' ? activeElement.contentWindow : window;
         ['keydown', 'keyup'].forEach(typeArg => {
-            [global.document, global].forEach(target => {
-                target.dispatchEvent(new KeyboardEvent(typeArg, { keyCode }));
+            [global.document.body, global].forEach(target => {
+                target.dispatchEvent(new KeyboardEvent(typeArg, { keyCode, bubbles: true }));
             });
         });
 


### PR DESCRIPTION
Fix an error that was occurring on the slides page at https://speakerdeck.com/

```
> document.activeElement
<body class=​"sd-app">​…​</body>​

> document.dispatchEvent(new KeyboardEvent('keydown', {keyCode: 39}))
Uncaught TypeError: Cannot read property 'toLowerCase' of undefined
    at e.value (embed.js:122)
    at <anonymous>:1:10
value @ embed.js:122
(anonymous) @ VM89:1
```