### PR TITLE
Fix device detection conditions

### DIFF
--- a/src/presentation-joy-con.js
+++ b/src/presentation-joy-con.js
@@ -1,4 +1,6 @@
 (() => {
+    const VENDOR_ID = '057e';
+    const DEVICE_ID = '2006';
     const [LEFT_BUTTON, RIGHT_BUTTON] = [0, 3];
     const [LEFT_ARROW_KEY_CODE, RIGHT_ARROW_KEY_CODE] = [37, 39];
 
@@ -19,7 +21,8 @@
     };
 
     addEventListener('gamepadconnected', e => {
-        if (gamepadIndex != null || !e.gamepad.id.includes('Joy-Con (L)')) {
+        const gamepadId = e.gamepad.id;
+        if (gamepadIndex != null || !gamepadId.includes(VENDOR_ID) || !gamepadId.includes(DEVICE_ID)) {
             return;
         }
         gamepadIndex = e.gamepad.index;


### PR DESCRIPTION
There are some environments where `Joy-Con (L)` is not included in `gamepad.id`.

https://gamepad-tester.com/codes

```
Wireless Gamepad (STANDARD GAMEPAD Vendor: 057e Product: 2006)
Wireless Gamepad (Vendor: 057e Product: 2006)
Joy-Con (L) (STANDARD GAMEPAD Vendor: 057e Product: 2006)
057e-2006-Wireless Gamepad
Joy-Con (L) (Vendor: 057e Product: 2006)
057e-2006-Joy-Con (L)
057e-2006-Nintendo Switch Left Joy-Con
Pro Controller (STANDARD GAMEPAD Vendor: 057e Product: 2006)
Nintendo Switch Joy-Cons (Vendor: 057e Product: 2006)
Pro Controller (Vendor: 057e Product: 2006)
057e-2006-Nintendo Switch Left Joy-Con imu
Scanner Receiver (STANDARD GAMEPAD Vendor: 057e Product: 2006)
057e-2006-Pro Controller
Nintendo Switch Joy-Con Horizontal (Vendor: 057e Product: 2006)
057e-2006-Nintendo Switch Joy-Cons
Nintendo Switch Left Joy-Con Serial (Vendor: 057e Product: 2006)
057e-2006-Nintendo Switch Left Joy-Con Serial
(Vendor: 057e Product: 2006)
057e-2006-UnKnown
```